### PR TITLE
Move concrete extractors out of Extractor file

### DIFF
--- a/lib/CsvExtractor.py
+++ b/lib/CsvExtractor.py
@@ -1,0 +1,13 @@
+from pyspark.sql import DataFrame
+from lib.Extractor import Extractor
+
+
+class CsvExtractor(Extractor):
+
+    def extract(self, source_location) -> DataFrame:
+        return (
+            self.spark.read.format("csv")
+            .option("header", "true")
+            .option("inferSchema", "true")
+            .load(source_location)
+        )

--- a/lib/Extractor.py
+++ b/lib/Extractor.py
@@ -7,22 +7,5 @@ class Extractor(metaclass=abc.ABCMeta):
         self.spark = spark
 
     @abc.abstractmethod
-    def extract(self):
+    def extract(self, source_location) -> DataFrame:
         pass
-
-
-class HiveExtractor(Extractor):
-
-    def extract(self, table) -> DataFrame:
-        return self.spark.sql(f"SELECT * FROM {table}")
-
-
-class CsvExtractor(Extractor):
-
-    def extract(self, path) -> DataFrame:
-        return (
-            self.spark.read.format("csv")
-            .option("header", "true")
-            .option("inferSchema", "true")
-            .load(path)
-        )

--- a/lib/ExtractorFactory.py
+++ b/lib/ExtractorFactory.py
@@ -1,4 +1,5 @@
-from lib.Extractor import HiveExtractor, CsvExtractor
+from lib.CsvExtractor import CsvExtractor
+from lib.HiveExtractor import HiveExtractor
 
 
 class ExtractorFactory:

--- a/lib/HiveExtractor.py
+++ b/lib/HiveExtractor.py
@@ -1,0 +1,8 @@
+from pyspark.sql import DataFrame
+from lib.Extractor import Extractor
+
+
+class HiveExtractor(Extractor):
+
+    def extract(self, source_location) -> DataFrame:
+        return self.spark.sql(f"SELECT * FROM {source_location}")

--- a/lib/test_extractor.py
+++ b/lib/test_extractor.py
@@ -2,7 +2,9 @@ import pytest
 
 from pyspark.sql import DataFrame
 from lib.Utils import get_spark_session
-from lib.Extractor import *
+
+from lib.CsvExtractor import CsvExtractor
+from lib.HiveExtractor import HiveExtractor
 from lib.ExtractorFactory import ExtractorFactory
 
 


### PR DESCRIPTION
Move concrete extractors out of `Extractor.py` file

Also, fix the signature of the `extract` method so that it is consistent between the abstract and concrete classes