### PR TITLE
Make ExtractorFactory into an abstract factory

### DIFF
--- a/lib/ExtractorFactory.py
+++ b/lib/ExtractorFactory.py
@@ -1,14 +1,11 @@
-from lib.CsvExtractor import CsvExtractor
-from lib.HiveExtractor import HiveExtractor
+import abc
+from lib.Extractor import Extractor
 
 
-class ExtractorFactory:
-
+class ExtractorFactory(metaclass=abc.ABCMeta):
     def __init__(self, conf):
         self.conf = conf
 
-    def make_extractor(self, spark):
-        if self.conf["enable.hive"] == "true":
-            return HiveExtractor(spark)
-
-        return CsvExtractor(spark)
+    @abc.abstractmethod
+    def make_extractor(self, spark) -> Extractor:
+        pass

--- a/lib/ExtractorFactoryImpl.py
+++ b/lib/ExtractorFactoryImpl.py
@@ -1,0 +1,13 @@
+from lib.ExtractorFactory import ExtractorFactory
+from lib.Extractor import Extractor
+from lib.CsvExtractor import CsvExtractor
+from lib.HiveExtractor import HiveExtractor
+
+
+class ExtractorFactoryImpl(ExtractorFactory):
+
+    def make_extractor(self, spark) -> Extractor:
+        if self.conf["enable.hive"] == "true":
+            return HiveExtractor(spark)
+
+        return CsvExtractor(spark)

--- a/lib/test_extractor.py
+++ b/lib/test_extractor.py
@@ -5,7 +5,7 @@ from lib.Utils import get_spark_session
 
 from lib.CsvExtractor import CsvExtractor
 from lib.HiveExtractor import HiveExtractor
-from lib.ExtractorFactory import ExtractorFactory
+from lib.ExtractorFactoryImpl import ExtractorFactoryImpl
 
 
 @pytest.fixture(scope="session")
@@ -38,7 +38,7 @@ def hive(spark):
 
 def test_extract_creates_dataframe_of_nine_rows(spark):
     conf = {"enable.hive": "false"}
-    f = ExtractorFactory(conf)
+    f = ExtractorFactoryImpl(conf)
     e = f.make_extractor(spark)
     df = e.extract("test_data/accounts/")
 
@@ -49,7 +49,7 @@ def test_extract_creates_dataframe_of_nine_rows(spark):
 
 def test_extract_from_hive_table_when_enable_hive_config_is_true(spark, hive):
     conf = {"enable.hive": "true"}
-    f = ExtractorFactory(conf)
+    f = ExtractorFactoryImpl(conf)
     e = f.make_extractor(spark)
     df = e.extract("test_db.accounts")
 


### PR DESCRIPTION
Previously, `ExtractorFactory` was a concrete class.

Make `ExtractorFactory` into an abstract factory so that dependency would be inverted in the application code. Implementation is done in `ExtractorFactoryImpl`