### PR TITLE
Support schema for CsvExtractor

### DIFF
--- a/conf/sbdl.conf
+++ b/conf/sbdl.conf
@@ -1,9 +1,12 @@
 [LOCAL]
 enable.hive = false
 hive.database = null
-accounts.data.location = test_data/accounts/
-party.data.location = test_data/parties/
-address.data.location = test_data/party_address/
+accounts.source.location = test_data/accounts/
+party.source.location = test_data/parties/
+address.source.location = test_data/party_address/
+accounts.schema = load_date date,active_ind int,account_id string,source_sys string,account_start_date timestamp,legal_title_1 string,legal_title_2 string,tax_id_type string,tax_id string,branch_code string,country string
+party.schema = load_date date,account_id string,party_id string,relation_type string,relation_start_date timestamp
+address.schema = load_date date,party_id string,address_line_1 string,address_line_2 string,city string,postal_code string,country_of_address string,address_start_date date
 account.filter = active_ind = 1
 party.filter =
 address.filter =
@@ -11,9 +14,12 @@ kafka.topic = sbdl_kafka_cloud
 [QA]
 enable.hive = true
 hive.database = sbdl_db_qa
-accounts.data.location = sbdl_db_qa.accounts
-party.data.location = sbdl_db_qa.parties
-address.data.location = sbdl_db_qa.party_address
+accounts.source.location = sbdl_db_qa.accounts
+party.source.location = sbdl_db_qa.parties
+address.source.location = sbdl_db_qa.party_address
+accounts.schema =
+party.schema =
+address.schema =
 account.filter = active_ind = 1
 party.filter =
 address.filter =
@@ -21,9 +27,12 @@ kafka.topic = sbdl_kafka_qa
 [PROD]
 enable.hive = true
 hive.database = sbdl_db
-accounts.data.location = sbdl_db.accounts
-party.data.location = sbdl_db.parties
-address.data.location = sbdl_db.party_address
+accounts.source.location = sbdl_db.accounts
+party.source.location = sbdl_db.parties
+address.source.location = sbdl_db.party_address
+accounts.schema =
+party.schema =
+address.schema =
 account.filter = active_ind = 1
 party.filter =
 address.filter =

--- a/lib/AccountsConfig.py
+++ b/lib/AccountsConfig.py
@@ -1,0 +1,13 @@
+class AccountsConfig:
+
+    def __init__(self, conf):
+        self.__source_location = conf["accounts.source.location"]
+        self.__schema = conf["accounts.schema"]
+
+    @property
+    def source_location(self):
+        return self.__source_location
+
+    @property
+    def schema(self):
+        return self.__schema

--- a/lib/CsvExtractor.py
+++ b/lib/CsvExtractor.py
@@ -1,13 +1,17 @@
 from pyspark.sql import DataFrame
 from lib.Extractor import Extractor
+from lib.MissingSchemaError import MissingSchemaError
 
 
 class CsvExtractor(Extractor):
 
-    def extract(self, source_location) -> DataFrame:
+    def extract(self, entity_config) -> DataFrame:
+        if len(entity_config.schema) == 0:
+            raise MissingSchemaError("Schema is required in sbdl.conf")
+
         return (
             self.spark.read.format("csv")
             .option("header", "true")
-            .option("inferSchema", "true")
-            .load(source_location)
+            .schema(entity_config.schema)
+            .load(entity_config.source_location)
         )

--- a/lib/Extractor.py
+++ b/lib/Extractor.py
@@ -7,5 +7,5 @@ class Extractor(metaclass=abc.ABCMeta):
         self.spark = spark
 
     @abc.abstractmethod
-    def extract(self, source_location) -> DataFrame:
+    def extract(self, entity_config) -> DataFrame:
         pass

--- a/lib/HiveExtractor.py
+++ b/lib/HiveExtractor.py
@@ -4,5 +4,5 @@ from lib.Extractor import Extractor
 
 class HiveExtractor(Extractor):
 
-    def extract(self, source_location) -> DataFrame:
-        return self.spark.sql(f"SELECT * FROM {source_location}")
+    def extract(self, entity_config) -> DataFrame:
+        return self.spark.sql(f"SELECT * FROM {entity_config.source_location}")

--- a/lib/MissingSchemaError.py
+++ b/lib/MissingSchemaError.py
@@ -1,0 +1,7 @@
+class MissingSchemaError(Exception):
+
+    def __init__(self, value):
+        self.value = value
+
+    def __str__(self):
+        return repr(self.value)

--- a/lib/PartiesConfig.py
+++ b/lib/PartiesConfig.py
@@ -1,0 +1,13 @@
+class PartiesConfig:
+
+    def __init__(self, conf):
+        self.__source_location = conf["party.source.location"]
+        self.__schema = conf["party.schema"]
+
+    @property
+    def source_location(self):
+        return self.__source_location
+
+    @property
+    def schema(self):
+        return self.__schema

--- a/lib/PartyAddressesConfig.py
+++ b/lib/PartyAddressesConfig.py
@@ -1,0 +1,13 @@
+class PartyAddressesConfig:
+
+    def __init__(self, conf):
+        self.__source_location = conf["address.source.location"]
+        self.__schema = conf["address.schema"]
+
+    @property
+    def source_location(self):
+        return self.__source_location
+
+    @property
+    def schema(self):
+        return self.__schema

--- a/lib/test_extractor.py
+++ b/lib/test_extractor.py
@@ -1,11 +1,24 @@
 import pytest
 
 from pyspark.sql import DataFrame
+from pyspark.sql.types import (
+    StructType,
+    StructField,
+    TimestampType,
+    LongType,
+    StringType,
+    DateType,
+)
+
 from lib.Utils import get_spark_session
 
 from lib.CsvExtractor import CsvExtractor
 from lib.HiveExtractor import HiveExtractor
 from lib.ExtractorFactoryImpl import ExtractorFactoryImpl
+from lib.MissingSchemaError import MissingSchemaError
+
+from lib.AccountsConfig import AccountsConfig
+from lib.PartiesConfig import PartiesConfig
 
 
 @pytest.fixture(scope="session")
@@ -37,10 +50,15 @@ def hive(spark):
 
 
 def test_extract_creates_dataframe_of_nine_rows(spark):
-    conf = {"enable.hive": "false"}
+    conf = {
+        "enable.hive": "false",
+        "accounts.source.location": "test_data/accounts/",
+        "accounts.schema": "load_date date,active_ind int,account_id string,source_sys string,account_start_date timestamp,legal_title_1 string,legal_title_2 string,tax_id_type string,tax_id string,branch_code string,country string",
+    }
     f = ExtractorFactoryImpl(conf)
     e = f.make_extractor(spark)
-    df = e.extract("test_data/accounts/")
+    accounts_config = AccountsConfig(conf)
+    df = e.extract(accounts_config)
 
     assert isinstance(df, DataFrame)
     assert isinstance(e, CsvExtractor)
@@ -48,10 +66,51 @@ def test_extract_creates_dataframe_of_nine_rows(spark):
 
 
 def test_extract_from_hive_table_when_enable_hive_config_is_true(spark, hive):
-    conf = {"enable.hive": "true"}
+    conf = {
+        "enable.hive": "true",
+        "accounts.source.location": "test_db.accounts",
+        "accounts.schema": "",
+    }
     f = ExtractorFactoryImpl(conf)
     e = f.make_extractor(spark)
-    df = e.extract("test_db.accounts")
+    accounts_config = AccountsConfig(conf)
+    df = e.extract(accounts_config)
 
     assert isinstance(e, HiveExtractor)
     assert df.count() == 2
+
+
+def test_csv_extractor_throws_when_schema_is_missing(spark):
+    conf = {
+        "enable.hive": "false",
+        "accounts.source.location": "test_data/accounts/",
+        "accounts.schema": "",
+    }
+    f = ExtractorFactoryImpl(conf)
+    e = f.make_extractor(spark)
+    accounts_config = AccountsConfig(conf)
+
+    with pytest.raises(MissingSchemaError):
+        df = e.extract(accounts_config)
+
+
+def test_schema_of_parties_dataframe_is_as_expected(spark):
+    expected_schema = [
+        StructField("load_date", DateType(), True),
+        StructField("account_id", StringType(), True),
+        StructField("party_id", StringType(), True),
+        StructField("relation_type", StringType(), True),
+        StructField("relation_start_date", TimestampType(), True),
+    ]
+
+    conf = {
+        "enable.hive": "false",
+        "party.source.location": "test_data/parties/",
+        "party.schema": "load_date date,account_id string,party_id string,relation_type string,relation_start_date timestamp",
+    }
+    ef = ExtractorFactoryImpl(conf)
+    e = ef.make_extractor(spark)
+    parties_config = PartiesConfig(conf)
+    df = e.extract(parties_config)
+
+    assert df.schema.fields == expected_schema

--- a/sbdl_main.py
+++ b/sbdl_main.py
@@ -6,6 +6,9 @@ from lib.logger import Log4j
 from lib.ConfigLoader import get_config
 from lib.ExtractorFactoryImpl import ExtractorFactoryImpl
 from lib.Extractor import Extractor
+from lib.AccountsConfig import AccountsConfig
+from lib.PartiesConfig import PartiesConfig
+from lib.PartyAddressesConfig import PartyAddressesConfig
 
 if __name__ == "__main__":
 
@@ -26,9 +29,13 @@ if __name__ == "__main__":
 
     logger.info("Extracting Source data")
 
-    df_accounts = e.extract(conf["accounts.data.location"])
-    df_parties = e.extract(conf["party.data.location"])
-    df_party_address = e.extract(conf["address.data.location"])
+    accounts_config = AccountsConfig(conf)
+    parties_config = PartiesConfig(conf)
+    party_address_config = PartyAddressesConfig(conf)
+
+    df_accounts = e.extract(accounts_config)
+    df_parties = e.extract(parties_config)
+    df_party_address = e.extract(party_address_config)
 
     logger.info("Extracted Source data")
 


### PR DESCRIPTION
Previously, extractor took a source data location as a string in order to create a dataframe. As this happens, the `CsvExtractor` would infer the schema of the CSV data.

The problem is that the inferred schema is incorrect. It would be better to use the user-defined schema instead.

A naive solution would be to pass another argument to the `extract()` method. The problem is, however, that this would violate the contract of the abstract method. As an example, the `HiveExtractor` does not need this parameter because the schema is already defined in the Hive table.

In this PR, the `extract()` method will take an entity-specific config object instead of the source data location. Three concrete entity-specific config objects will be introduced:
* `AccountsConfig`
* `PartiesConfig`
* `PartyAddressesConfig`

Each of them will have properties specifying the following:
* source data location
* schema (if needed)

Schema will be required in `sbdl.conf` for the `CsvExtractor`.