### PR TITLE
Add EntitiesConfig abstract class

### DIFF
--- a/lib/AccountsConfig.py
+++ b/lib/AccountsConfig.py
@@ -1,13 +1,12 @@
-class AccountsConfig:
+from lib.EntitiesConfig import EntitiesConfig
 
-    def __init__(self, conf):
-        self.__source_location = conf["accounts.source.location"]
-        self.__schema = conf["accounts.schema"]
+
+class AccountsConfig(EntitiesConfig):
 
     @property
     def source_location(self):
-        return self.__source_location
+        return self.conf["accounts.source.location"]
 
     @property
     def schema(self):
-        return self.__schema
+        return self.conf["accounts.schema"]

--- a/lib/CsvExtractor.py
+++ b/lib/CsvExtractor.py
@@ -1,11 +1,12 @@
 from pyspark.sql import DataFrame
 from lib.Extractor import Extractor
 from lib.MissingSchemaError import MissingSchemaError
+from lib.EntitiesConfig import EntitiesConfig
 
 
 class CsvExtractor(Extractor):
 
-    def extract(self, entity_config) -> DataFrame:
+    def extract(self, entity_config: EntitiesConfig) -> DataFrame:
         if len(entity_config.schema) == 0:
             raise MissingSchemaError("Schema is required in sbdl.conf")
 

--- a/lib/EntitiesConfig.py
+++ b/lib/EntitiesConfig.py
@@ -1,0 +1,17 @@
+import abc
+
+
+class EntitiesConfig(metaclass=abc.ABCMeta):
+
+    def __init__(self, conf):
+        self.conf = conf
+
+    @property
+    @abc.abstractmethod
+    def source_location(self):
+        pass
+
+    @property
+    @abc.abstractmethod
+    def schema(self):
+        pass

--- a/lib/Extractor.py
+++ b/lib/Extractor.py
@@ -1,5 +1,6 @@
 import abc
 from pyspark.sql import DataFrame
+from lib.EntitiesConfig import EntitiesConfig
 
 
 class Extractor(metaclass=abc.ABCMeta):
@@ -7,5 +8,5 @@ class Extractor(metaclass=abc.ABCMeta):
         self.spark = spark
 
     @abc.abstractmethod
-    def extract(self, entity_config) -> DataFrame:
+    def extract(self, entity_config: EntitiesConfig) -> DataFrame:
         pass

--- a/lib/HiveExtractor.py
+++ b/lib/HiveExtractor.py
@@ -1,8 +1,9 @@
 from pyspark.sql import DataFrame
 from lib.Extractor import Extractor
+from lib.EntitiesConfig import EntitiesConfig
 
 
 class HiveExtractor(Extractor):
 
-    def extract(self, entity_config) -> DataFrame:
+    def extract(self, entity_config: EntitiesConfig) -> DataFrame:
         return self.spark.sql(f"SELECT * FROM {entity_config.source_location}")

--- a/lib/PartiesConfig.py
+++ b/lib/PartiesConfig.py
@@ -1,13 +1,12 @@
-class PartiesConfig:
+from lib.EntitiesConfig import EntitiesConfig
 
-    def __init__(self, conf):
-        self.__source_location = conf["party.source.location"]
-        self.__schema = conf["party.schema"]
+
+class PartiesConfig(EntitiesConfig):
 
     @property
     def source_location(self):
-        return self.__source_location
+        return self.conf["party.source.location"]
 
     @property
     def schema(self):
-        return self.__schema
+        return self.conf["party.schema"]

--- a/lib/PartyAddressesConfig.py
+++ b/lib/PartyAddressesConfig.py
@@ -1,13 +1,12 @@
-class PartyAddressesConfig:
+from lib.EntitiesConfig import EntitiesConfig
 
-    def __init__(self, conf):
-        self.__source_location = conf["address.source.location"]
-        self.__schema = conf["address.schema"]
+
+class PartyAddressesConfig(EntitiesConfig):
 
     @property
     def source_location(self):
-        return self.__source_location
+        return self.conf["address.source.location"]
 
     @property
     def schema(self):
-        return self.__schema
+        return self.conf["address.schema"]


### PR DESCRIPTION
Previously, three concrete config classes were introduced. They all share the same set of properties.

In this PR, add an abstract class named `EntitiesConfig` so that the config classes can be derived from it.