### PR TITLE
Use default value when conf is missing in EntitiesConfig

### DIFF
--- a/lib/AccountsConfig.py
+++ b/lib/AccountsConfig.py
@@ -5,8 +5,8 @@ class AccountsConfig(EntitiesConfig):
 
     @property
     def source_location(self):
-        return self.conf["accounts.source.location"]
+        return self.conf.get("accounts.source.location", self.default_value)
 
     @property
     def schema(self):
-        return self.conf["accounts.schema"]
+        return self.conf.get("accounts.schema", self.default_value)

--- a/lib/EntitiesConfig.py
+++ b/lib/EntitiesConfig.py
@@ -5,6 +5,7 @@ class EntitiesConfig(metaclass=abc.ABCMeta):
 
     def __init__(self, conf):
         self.conf = conf
+        self.default_value = ""
 
     @property
     @abc.abstractmethod

--- a/lib/PartiesConfig.py
+++ b/lib/PartiesConfig.py
@@ -5,8 +5,8 @@ class PartiesConfig(EntitiesConfig):
 
     @property
     def source_location(self):
-        return self.conf["party.source.location"]
+        return self.conf.get("party.source.location", self.default_value)
 
     @property
     def schema(self):
-        return self.conf["party.schema"]
+        return self.conf.get("party.schema", self.default_value)

--- a/lib/PartyAddressesConfig.py
+++ b/lib/PartyAddressesConfig.py
@@ -5,8 +5,8 @@ class PartyAddressesConfig(EntitiesConfig):
 
     @property
     def source_location(self):
-        return self.conf["address.source.location"]
+        return self.conf.get("address.source.location", self.default_value)
 
     @property
     def schema(self):
-        return self.conf["address.schema"]
+        return self.conf.get("address.schema", self.default_value)

--- a/lib/test_entities_config.py
+++ b/lib/test_entities_config.py
@@ -1,0 +1,45 @@
+import pytest
+
+from lib.AccountsConfig import AccountsConfig
+from lib.PartiesConfig import PartiesConfig
+from lib.PartyAddressesConfig import PartyAddressesConfig
+
+
+def test_accounts_config_returns_empty_string_when_source_location_or_schema_is_missing():
+    conf = {}
+    accounts_config = AccountsConfig(conf)
+
+    assert accounts_config.source_location == accounts_config.default_value
+    assert accounts_config.schema == accounts_config.default_value
+
+
+def test_parties_config_returns_empty_string_when_source_location_or_schema_is_missing():
+    conf = {}
+    parties_config = PartiesConfig(conf)
+
+    assert parties_config.source_location == parties_config.default_value
+    assert parties_config.schema == parties_config.default_value
+
+
+def test_party_addresses_config_returns_empty_string_when_source_location_or_schema_is_missing():
+    conf = {}
+    party_addresses_config = PartyAddressesConfig(conf)
+
+    assert (
+        party_addresses_config.source_location == party_addresses_config.default_value
+    )
+    assert party_addresses_config.schema == party_addresses_config.default_value
+
+
+def test_accounts_config_returns_source_location_in_conf():
+    expected_source_location = "source/location/"
+    expected_schema = "id int,name, string"
+
+    conf = {
+        "accounts.source.location": expected_source_location,
+        "accounts.schema": expected_schema,
+    }
+    accounts_config = AccountsConfig(conf)
+
+    assert accounts_config.source_location == expected_source_location
+    assert accounts_config.schema == expected_schema


### PR DESCRIPTION
When a configuration is missing in sbdl.conf, `EntitiesConfig` throws `KeyNameError` upon instantiation.

In this PR, use default value (empty string) when configuration is missing