### PR TITLE
EntitiesConfig throws when source location or schema is missing

### DIFF
--- a/lib/AccountsConfig.py
+++ b/lib/AccountsConfig.py
@@ -5,8 +5,8 @@ class AccountsConfig(EntitiesConfig):
 
     @property
     def source_location(self):
-        return self.conf.get("accounts.source.location", self.default_value)
+        return self._get_source_location("accounts.source.location")
 
     @property
     def schema(self):
-        return self.conf.get("accounts.schema", self.default_value)
+        return self._get_schema("accounts.schema")

--- a/lib/EntitiesConfig.py
+++ b/lib/EntitiesConfig.py
@@ -1,5 +1,8 @@
 import abc
 
+from lib.MissingSourceLocationError import MissingSourceLocationError
+from lib.MissingSchemaError import MissingSchemaError
+
 
 class EntitiesConfig(metaclass=abc.ABCMeta):
 
@@ -16,3 +19,19 @@ class EntitiesConfig(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def schema(self):
         pass
+
+    def _get_source_location(self, key: str) -> str:
+        value = self.conf.get(key, self.default_value)
+
+        if len(value) == 0:
+            raise MissingSourceLocationError(f"{key} is required in sbdl.conf")
+
+        return value
+
+    def _get_schema(self, key: str) -> str:
+        value = self.conf.get(key, self.default_value)
+
+        if len(value) == 0:
+            raise MissingSchemaError(f"{key} is required in sbdl.conf")
+
+        return value

--- a/lib/PartiesConfig.py
+++ b/lib/PartiesConfig.py
@@ -5,8 +5,8 @@ class PartiesConfig(EntitiesConfig):
 
     @property
     def source_location(self):
-        return self.conf.get("party.source.location", self.default_value)
+        return self._get_source_location("party.source.location")
 
     @property
     def schema(self):
-        return self.conf.get("party.schema", self.default_value)
+        return self._get_schema("party.schema")

--- a/lib/PartyAddressesConfig.py
+++ b/lib/PartyAddressesConfig.py
@@ -5,8 +5,8 @@ class PartyAddressesConfig(EntitiesConfig):
 
     @property
     def source_location(self):
-        return self.conf.get("address.source.location", self.default_value)
+        return self._get_source_location("address.source.location")
 
     @property
     def schema(self):
-        return self.conf.get("address.schema", self.default_value)
+        return self._get_schema("address.schema")

--- a/lib/test_entities_config.py
+++ b/lib/test_entities_config.py
@@ -4,31 +4,56 @@ from lib.AccountsConfig import AccountsConfig
 from lib.PartiesConfig import PartiesConfig
 from lib.PartyAddressesConfig import PartyAddressesConfig
 
+from lib.MissingSourceLocationError import MissingSourceLocationError
+from lib.MissingSchemaError import MissingSchemaError
 
-def test_accounts_config_returns_empty_string_when_source_location_or_schema_is_missing():
+
+def test_accounts_config_throws_when_source_location_is_missing():
     conf = {}
     accounts_config = AccountsConfig(conf)
 
-    assert accounts_config.source_location == accounts_config.default_value
-    assert accounts_config.schema == accounts_config.default_value
+    with pytest.raises(MissingSourceLocationError):
+        accounts_config.source_location
 
 
-def test_parties_config_returns_empty_string_when_source_location_or_schema_is_missing():
+def test_accounts_config_throws_when_schema_is_missing():
+    conf = {}
+    accounts_config = AccountsConfig(conf)
+
+    with pytest.raises(MissingSchemaError):
+        accounts_config.schema
+
+
+def test_parties_config_throws_when_source_location_is_missing():
     conf = {}
     parties_config = PartiesConfig(conf)
 
-    assert parties_config.source_location == parties_config.default_value
-    assert parties_config.schema == parties_config.default_value
+    with pytest.raises(MissingSourceLocationError):
+        parties_config.source_location
 
 
-def test_party_addresses_config_returns_empty_string_when_source_location_or_schema_is_missing():
+def test_parties_config_throws_when_schema_is_missing():
+    conf = {}
+    parties_config = PartiesConfig(conf)
+
+    with pytest.raises(MissingSchemaError):
+        parties_config.schema
+
+
+def test_party_addresses_config_throws_when_source_location_is_missing():
     conf = {}
     party_addresses_config = PartyAddressesConfig(conf)
 
-    assert (
-        party_addresses_config.source_location == party_addresses_config.default_value
-    )
-    assert party_addresses_config.schema == party_addresses_config.default_value
+    with pytest.raises(MissingSourceLocationError):
+        party_addresses_config.source_location
+
+
+def test_party_addresses_config_throws_when_schema_is_missing():
+    conf = {}
+    party_addresses_config = PartyAddressesConfig(conf)
+
+    with pytest.raises(MissingSchemaError):
+        party_addresses_config.schema
 
 
 def test_accounts_config_returns_source_location_in_conf():


### PR DESCRIPTION
Previously, throwing of `MissingSourceLocationError` or `MissingSchemaError` was deferred until `extract()` method was invoked in the `Extractor`.

In this PR, throw them early in the `EntitiesConfig` instead