### PR TITLE
Add test case with two rows to transform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ metastore_db/*
 spark-warehouse/*
 derby.log
 tests/__pycache__/*
+schema/__pycache__/*

--- a/schema/PartiesSchema.py
+++ b/schema/PartiesSchema.py
@@ -1,0 +1,23 @@
+from pyspark.sql.types import (
+    StructType,
+    StructField,
+    StringType,
+    NullType,
+    TimestampType,
+    DateType,
+)
+
+
+class PartiesSchema:
+
+    @staticmethod
+    def get_schema():
+        return StructType(
+            [
+                StructField("load_date", DateType()),
+                StructField("account_id", StringType()),
+                StructField("party_id", StringType()),
+                StructField("relation_type", StringType()),
+                StructField("relation_start_date", TimestampType()),
+            ]
+        )

--- a/schema/RelationsSchema.py
+++ b/schema/RelationsSchema.py
@@ -1,0 +1,49 @@
+from pyspark.sql.types import (
+    StructType,
+    StructField,
+    StringType,
+    NullType,
+    TimestampType,
+)
+
+
+class RelationsSchema:
+
+    @staticmethod
+    def get_schema():
+        return StructType(
+            [
+                StructField("account_id", StringType()),
+                StructField("party_id", StringType()),
+                StructField(
+                    "partyIdentifier",
+                    StructType(
+                        [
+                            StructField("operation", StringType()),
+                            StructField("newValue", StringType()),
+                            StructField("oldValue", NullType()),
+                        ]
+                    ),
+                ),
+                StructField(
+                    "partyRelationshipType",
+                    StructType(
+                        [
+                            StructField("operation", StringType()),
+                            StructField("newValue", StringType()),
+                            StructField("oldValue", NullType()),
+                        ]
+                    ),
+                ),
+                StructField(
+                    "partyRelationStartDateTime",
+                    StructType(
+                        [
+                            StructField("operation", StringType()),
+                            StructField("newValue", TimestampType()),
+                            StructField("oldValue", NullType()),
+                        ]
+                    ),
+                ),
+            ]
+        )

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -17,20 +17,6 @@ def spark():
     return get_spark_session("LOCAL")
 
 
-def createPartiesDataFrame(spark, rows):
-    return (
-        spark.createDataFrame(rows)
-        .toDF(
-            "load_date",
-            "account_id",
-            "party_id",
-            "relation_type",
-            "relation_start_date",
-        )
-        .repartition(2)
-    )
-
-
 def test_transform_dataframe_with_one_row(spark):
 
     expected_rows = [


### PR DESCRIPTION
Add test case with two rows to transform

Schemas are moved to a `schema` package. Although these are used by the unit tests only (and they duplicate `EntitesConfig.schema` in some cases), the intent is to keep each test case tidy by not hardcoding the schema in the test file itself.